### PR TITLE
Fix TracerArrayConversionError when Config.cast_rays_in_train_step=True

### DIFF
--- a/internal/camera_utils.py
+++ b/internal/camera_utils.py
@@ -88,7 +88,7 @@ def convert_to_ndc(origins: _Array,
 
   # Perspective projection into NDC for the t = infinity far points
   #     origins + infinity * directions
-  infinity_ndc = np.stack([xmult * dx / dz, ymult * dy / dz,
+  infinity_ndc = xnp.stack([xmult * dx / dz, ymult * dy / dz,
                            xnp.ones_like(oz)],
                           axis=-1)
 
@@ -616,9 +616,9 @@ def pixels_to_rays(
 
   else:
     # Convert ray origins and directions into projective NDC space.
-    origins_dx, _ = convert_to_ndc(origins, dx, pixtocam_ndc)
-    origins_dy, _ = convert_to_ndc(origins, dy, pixtocam_ndc)
-    origins, directions = convert_to_ndc(origins, directions, pixtocam_ndc)
+    origins_dx, _ = convert_to_ndc(origins, dx, pixtocam_ndc, xnp=xnp)
+    origins_dy, _ = convert_to_ndc(origins, dy, pixtocam_ndc, xnp=xnp)
+    origins, directions = convert_to_ndc(origins, directions, pixtocam_ndc, xnp=xnp)
 
     # In NDC space, we use the offset between origins instead of directions.
     dx_norm = xnp.linalg.norm(origins_dx - origins, axis=-1)


### PR DESCRIPTION
When setting `Config.cast_rays_in_train_step = True`, the ray batches for training are sampled in `train_step`. i.e., the runtime `numpy` should be `jax.numpy`. However,  the argument `xnp` is not passed to the function `convert_to_ndc`, which causes the error like: 

```
jax._src.errors.TracerArrayConversionError: The numpy.ndarray conversion method  __array__() was called on the JAX Tracer object Traced<ShapedArray(float32[204
8,1,1])>with<DynamicJaxprTrace(level=0/1)>
```