### PR TITLE
Update pycolmap documentation from rmbrualla to trueprice.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ pip install --upgrade pip
 # Install requirements.
 pip install -r requirements.txt
 
-# Manually install rmbrualla's `pycolmap` (don't use pip's! It's different).
-git clone https://github.com/rmbrualla/pycolmap.git ./internal/pycolmap
+# Manually install trueprice's `pycolmap` (don't use pip's! It's different).
+git clone https://github.com/trueprice/pycolmap.git ./internal/pycolmap
 
 # Confirm that all the unit tests pass.
 ./scripts/run_all_unit_tests.sh


### PR DESCRIPTION
In the documentation, it is mentioned that we can use fisheye camera model, but you probably forgot to mention that we should use another version of `pycolmap`,  `trueprice`, because:

1. rmbrualla does not support OPENCV_FISHEYE camera model
2. rmbrualla's commits has been already merged to `trueprice` (-`rmbrualla` is a fork of `trueprice`-)
--
Tip for testers: do not forgot to update the `Config.near` if you are using a fisheye camera ;)